### PR TITLE
fix: add is_active property to mockUser in password reset test

### DIFF
--- a/xconfess-backend/src/auth/password-reset.service.spec.ts
+++ b/xconfess-backend/src/auth/password-reset.service.spec.ts
@@ -16,6 +16,7 @@ describe('PasswordResetService', () => {
     username: 'testuser',
     email: 'test@example.com',
     password: 'hashedpassword',
+    is_active: true,
     resetPasswordToken: null,
     resetPasswordExpires: null,
     createdAt: new Date(),


### PR DESCRIPTION
- Add missing is_active property to mockUser object
- Fix TypeScript error in password-reset.service.spec.ts
- Ensure mock user matches User entity structure