### PR TITLE
feat: add anonymous context middleware

### DIFF
--- a/xconfess-backend/package.json
+++ b/xconfess-backend/package.json
@@ -37,7 +37,8 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "sanitize-html": "^2.17.0",
-    "typeorm": "^0.3.22"
+    "typeorm": "^0.3.22",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -70,7 +71,8 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.20.0"
+    "typescript-eslint": "^8.20.0",
+    "@types/uuid": "^9.0.8"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/xconfess-backend/src/comment/comment.module.ts
+++ b/xconfess-backend/src/comment/comment.module.ts
@@ -1,0 +1,20 @@
+import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CommentController } from './comment.controller';
+import { CommentService } from './comment.service';
+import { Comment } from './entities/comment.entity';
+import { AnonymousContextMiddleware } from '../middleware/anonymous-context.middleware';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Comment])],
+  controllers: [CommentController],
+  providers: [CommentService],
+  exports: [CommentService],
+})
+export class CommentModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(AnonymousContextMiddleware)
+      .forRoutes('comments');
+  }
+} 

--- a/xconfess-backend/src/confession/confession.module.ts
+++ b/xconfess-backend/src/confession/confession.module.ts
@@ -1,8 +1,9 @@
-import { Module, forwardRef } from '@nestjs/common';
+import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AnonymousConfessionRepository } from './repository/confession.repository';
 import { AnonymousConfession } from './entities/confession.entity';
 import { ReactionModule } from '../reaction/reaction.module';
+import { AnonymousContextMiddleware } from '../middleware/anonymous-context.middleware';
 
 @Module({
   imports: [
@@ -12,4 +13,10 @@ import { ReactionModule } from '../reaction/reaction.module';
   providers: [AnonymousConfessionRepository],
   exports: [AnonymousConfessionRepository],
 })
-export class ConfessionModule {}
+export class ConfessionModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(AnonymousContextMiddleware)
+      .forRoutes('confessions');
+  }
+}

--- a/xconfess-backend/src/middleware/anonymous-context.middleware.ts
+++ b/xconfess-backend/src/middleware/anonymous-context.middleware.ts
@@ -1,0 +1,30 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+
+@Injectable()
+export class AnonymousContextMiddleware implements NestMiddleware {
+  private readonly ANONYMOUS_CONTEXT_HEADER = 'x-anonymous-context-id';
+  private readonly ANONYMOUS_CONTEXT_PREFIX = 'anon_';
+
+  use(req: Request, res: Response, next: NextFunction) {
+    // Only add anonymous context for authenticated users
+    if (req.user) {
+      // Generate a unique anonymous context ID
+      const anonymousContextId = this.generateAnonymousContextId();
+      
+      // Add the header to the request
+      req.headers[this.ANONYMOUS_CONTEXT_HEADER] = anonymousContextId;
+      
+      // Store the anonymous context ID in the request object for later use
+      req['anonymousContextId'] = anonymousContextId;
+    }
+    
+    next();
+  }
+
+  private generateAnonymousContextId(): string {
+    // Generate a UUID and prefix it with 'anon_' to make it easily identifiable
+    return `${this.ANONYMOUS_CONTEXT_PREFIX}${uuidv4()}`;
+  }
+} 

--- a/xconfess-backend/src/middleware/anonymous-context.module.ts
+++ b/xconfess-backend/src/middleware/anonymous-context.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { AnonymousContextMiddleware } from './anonymous-context.middleware';
+
+@Module({
+  providers: [AnonymousContextMiddleware],
+  exports: [AnonymousContextMiddleware],
+})
+export class AnonymousContextModule {} 

--- a/xconfess-backend/test/anonymous-context.middleware.spec.ts
+++ b/xconfess-backend/test/anonymous-context.middleware.spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AnonymousContextMiddleware } from '../src/middleware/anonymous-context.middleware';
+import { AnonymousContextModule } from '../src/middleware/anonymous-context.module';
+import { JwtAuthGuard } from '../src/auth/guards/jwt-auth.guard';
+import { User } from '../src/user/entities/user.entity';
+
+describe('AnonymousContextMiddleware (e2e)', () => {
+  let app: INestApplication;
+  let middleware: AnonymousContextMiddleware;
+
+  const mockUser: User = {
+    id: 1,
+    username: 'testuser',
+    email: 'test@example.com',
+    password: 'hashedpassword',
+    is_active: true,
+    resetPasswordToken: null,
+    resetPasswordExpires: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    confessions: [],
+  };
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AnonymousContextModule],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate: (context) => {
+          const request = context.switchToHttp().getRequest();
+          request.user = mockUser;
+          return true;
+        },
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    middleware = moduleFixture.get<AnonymousContextMiddleware>(AnonymousContextMiddleware);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should add anonymous context header for authenticated requests', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/test')
+      .set('Authorization', 'Bearer test-token');
+
+    expect(response.headers['x-anonymous-context-id']).toBeDefined();
+    expect(response.headers['x-anonymous-context-id']).toMatch(/^anon_[a-f0-9-]+$/);
+  });
+
+  it('should generate unique anonymous context IDs for different requests', async () => {
+    const response1 = await request(app.getHttpServer())
+      .get('/test')
+      .set('Authorization', 'Bearer test-token');
+
+    const response2 = await request(app.getHttpServer())
+      .get('/test')
+      .set('Authorization', 'Bearer test-token');
+
+    expect(response1.headers['x-anonymous-context-id']).not.toBe(
+      response2.headers['x-anonymous-context-id'],
+    );
+  });
+
+  it('should not add anonymous context header for unauthenticated requests', async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AnonymousContextModule],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate: () => false,
+      })
+      .compile();
+
+    const app = moduleFixture.createNestApplication();
+    await app.init();
+
+    const response = await request(app.getHttpServer()).get('/test');
+
+    expect(response.headers['x-anonymous-context-id']).toBeUndefined();
+    await app.close();
+  });
+}); 


### PR DESCRIPTION
# Add Anonymous Context Middleware

## Overview
This PR implements a middleware for injecting unique anonymous context IDs into authenticated requests. The middleware helps maintain user anonymity while ensuring traceability for confessions and comments.

## Changes
- Added `AnonymousContextMiddleware` for generating and injecting unique anonymous context IDs
- Created `AnonymousContextModule` for middleware configuration
- Added integration tests for middleware functionality
- Integrated middleware with confession and comment routes
- Added uuid dependency for generating unique IDs

## Features
- Generates unique anonymous context IDs for each authenticated request
- Adds `x-anonymous-context-id` header to requests
- Only applies to authenticated users
- Maintains user anonymity by not persisting identifiable data
- Easy to extend and modify

## Testing
Run the tests using:
```bash
npm run test
```

## Related Issues
Closes #43r

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced middleware that assigns a unique anonymous context ID to authenticated requests, enhancing privacy and request tracking.
  - Added new modules to integrate and manage the anonymous context middleware for both comments and confessions.

- **Tests**
  - Implemented end-to-end tests to verify correct behavior of the anonymous context middleware for both authenticated and unauthenticated requests.

- **Chores**
  - Added new dependencies to support UUID generation and type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->