### PR TITLE
Implemented confession view count

### DIFF
--- a/xconfess-backend/data-source.ts
+++ b/xconfess-backend/data-source.ts
@@ -1,0 +1,14 @@
+import { DataSource } from 'typeorm';
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+export default new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT),
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  entities: [__dirname + '/src/**/*.entity.{ts,js}'],
+  migrations: [__dirname + '/migrations/*.{ts,js}'],
+});

--- a/xconfess-backend/data-source.ts
+++ b/xconfess-backend/data-source.ts
@@ -2,10 +2,19 @@ import { DataSource } from 'typeorm';
 import * as dotenv from 'dotenv';
 dotenv.config();
 
+if (!process.env.DB_HOST || !process.env.DB_PORT || !process.env.DB_USERNAME || !process.env.DB_PASSWORD || !process.env.DB_NAME) {
+  throw new Error('Missing required database environment variables');
+}
+
+const dbPort = parseInt(process.env.DB_PORT, 10);
+if (isNaN(dbPort)) {
+  throw new Error('DB_PORT must be a valid number');
+}
+
 export default new DataSource({
   type: 'postgres',
   host: process.env.DB_HOST,
-  port: Number(process.env.DB_PORT),
+  port: dbPort,
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME,

--- a/xconfess-backend/migrations/add-view-count-to-confessions.sql
+++ b/xconfess-backend/migrations/add-view-count-to-confessions.sql
@@ -1,0 +1,2 @@
+-- Migration: Add view_count to confessions
+ALTER TABLE confessions ADD COLUMN view_count INTEGER NOT NULL DEFAULT 0;

--- a/xconfess-backend/package-lock.json
+++ b/xconfess-backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs-modules/ioredis": "^2.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/mapped-types": "*",
@@ -17,8 +18,10 @@
         "@nestjs/throttler": "^6.4.0",
         "@types/nodemailer": "^6.4.17",
         "bcrypt": "^5.1.1",
+        "bullmq": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "ioredis": "^5.3.2",
         "nodemailer": "^7.0.3",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
@@ -26,7 +29,8 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "sanitize-html": "^2.17.0",
-        "typeorm": "^0.3.22"
+        "typeorm": "^0.3.22",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -46,6 +50,7 @@
         "@types/node": "^22.15.30",
         "@types/sanitize-html": "^2.16.0",
         "@types/supertest": "^6.0.3",
+        "@types/uuid": "^9.0.8",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
@@ -1151,6 +1156,11 @@
         }
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "license": "ISC",
@@ -1727,6 +1737,78 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.1",
       "dev": true,
@@ -2027,6 +2109,113 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@nestjs-modules/ioredis": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs-modules/ioredis/-/ioredis-2.0.2.tgz",
+      "integrity": "sha512-8pzSvT8R3XP6p8ZzQmEN8OnY0yWrJ/elFhwQK+PID2zf1SLBkAZ18bDcx3SKQ2atledt0gd9kBeP5xT4MlyS7Q==",
+      "optionalDependencies": {
+        "@nestjs/terminus": "10.2.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": ">=6.7.0",
+        "@nestjs/core": ">=6.7.0",
+        "ioredis": ">=5.0.0"
+      }
+    },
+    "node_modules/@nestjs-modules/ioredis/node_modules/@nestjs/terminus": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-10.2.0.tgz",
+      "integrity": "sha512-zPs98xvJ4ogEimRQOz8eU90mb7z+W/kd/mL4peOgrJ/VqER+ibN2Cboj65uJZW3XuNhpOqaeYOJte86InJd44A==",
+      "optional": true,
+      "dependencies": {
+        "boxen": "5.1.2",
+        "check-disk-space": "3.4.0"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "*",
+        "@grpc/proto-loader": "*",
+        "@mikro-orm/core": "*",
+        "@mikro-orm/nestjs": "*",
+        "@nestjs/axios": "^1.0.0 || ^2.0.0 || ^3.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "@nestjs/microservices": "^9.0.0 || ^10.0.0",
+        "@nestjs/mongoose": "^9.0.0 || ^10.0.0",
+        "@nestjs/sequelize": "^9.0.0 || ^10.0.0",
+        "@nestjs/typeorm": "^9.0.0 || ^10.0.0",
+        "@prisma/client": "*",
+        "mongoose": "*",
+        "reflect-metadata": "0.1.x",
+        "rxjs": "7.x",
+        "sequelize": "*",
+        "typeorm": "*"
+      },
+      "peerDependenciesMeta": {
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "@grpc/proto-loader": {
+          "optional": true
+        },
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/nestjs": {
+          "optional": true
+        },
+        "@nestjs/axios": {
+          "optional": true
+        },
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/mongoose": {
+          "optional": true
+        },
+        "@nestjs/sequelize": {
+          "optional": true
+        },
+        "@nestjs/typeorm": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "mongoose": {
+          "optional": true
+        },
+        "sequelize": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs-modules/ioredis/node_modules/@nestjs/typeorm": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-10.0.2.tgz",
+      "integrity": "sha512-H738bJyydK4SQkRCTeh1aFBxoO1E9xdL/HaLGThwrqN95os5mEyAtK7BLADOS+vldP4jDZ2VQPLj4epWwRqCeQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "uuid": "9.0.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0",
+        "rxjs": "^7.2.0",
+        "typeorm": "^0.3.0"
+      }
+    },
+    "node_modules/@nestjs-modules/ioredis/node_modules/reflect-metadata": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
+      "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@nestjs/cli": {
       "version": "11.0.7",
@@ -3206,6 +3395,12 @@
         "@types/superagent": "^8.1.0"
       }
     },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
+    },
     "node_modules/@types/validator": {
       "version": "13.15.1",
       "license": "MIT"
@@ -4273,6 +4468,15 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "dev": true,
@@ -4639,6 +4843,90 @@
         "node": ">=18"
       }
     },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "optional": true,
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "license": "MIT",
@@ -4747,6 +5035,20 @@
       "version": "1.1.2",
       "license": "MIT"
     },
+    "node_modules/bullmq": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.56.0.tgz",
+      "integrity": "sha512-j5ct2tdc9M8PKcjhJw+euO24BsO1wXBAkNGXYI1R1qvh7FvRldZ5wtLixLWqQ4/crafj0Vrwi+y1kXFXMwBJFA==",
+      "dependencies": {
+        "cron-parser": "^4.9.0",
+        "ioredis": "^5.4.1",
+        "msgpackr": "^1.11.2",
+        "node-abort-controller": "^3.1.1",
+        "semver": "^7.5.4",
+        "tslib": "^2.0.0",
+        "uuid": "^9.0.0"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "dependencies": {
@@ -4850,7 +5152,7 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4875,6 +5177,15 @@
       "version": "0.7.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/check-disk-space": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
+      "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==",
+      "optional": true,
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -4935,6 +5246,18 @@
         "@types/validator": "^13.11.8",
         "libphonenumber-js": "^1.11.1",
         "validator": "^13.9.0"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -5031,6 +5354,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -5246,6 +5577,17 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "license": "MIT",
@@ -5356,6 +5698,14 @@
     "node_modules/delegates": {
       "version": "1.0.0",
       "license": "MIT"
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -6621,7 +6971,7 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6840,6 +7190,29 @@
       "license": "ISC",
       "dependencies": {
         "kind-of": "^6.0.2"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.1.tgz",
+      "integrity": "sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/ipaddr.js": {
@@ -7886,9 +8259,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -7956,6 +8339,14 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {
@@ -8182,6 +8573,35 @@
       "version": "2.1.3",
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.4.tgz",
+      "integrity": "sha512-uaff7RG9VIC4jacFW9xzL3jc0iM32DNHe4jYVycBcjUePT/Klnfj7pqtWJt9khvDFizmjN2TlYniYmSS2LIaZg==",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
     "node_modules/multer": {
       "version": "2.0.1",
       "license": "MIT",
@@ -8276,7 +8696,6 @@
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-addon-api": {
@@ -8307,6 +8726,20 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -9124,6 +9557,25 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "license": "Apache-2.0"
@@ -9693,6 +10145,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "license": "MIT",
@@ -9930,7 +10387,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -10692,6 +11149,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/typeorm/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "devOptional": true,
@@ -10822,14 +11291,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -11109,6 +11579,18 @@
       "license": "ISC",
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/xconfess-backend/package.json
+++ b/xconfess-backend/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs-modules/ioredis": "^2.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/mapped-types": "*",
@@ -28,8 +29,10 @@
     "@nestjs/throttler": "^6.4.0",
     "@types/nodemailer": "^6.4.17",
     "bcrypt": "^5.1.1",
+    "bullmq": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "ioredis": "^5.3.2",
     "nodemailer": "^7.0.3",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
@@ -38,9 +41,7 @@
     "rxjs": "^7.8.1",
     "sanitize-html": "^2.17.0",
     "typeorm": "^0.3.22",
-    "uuid": "^9.0.1",
-    "bullmq": "^5.1.1",
-    "ioredis": "^5.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -60,6 +61,7 @@
     "@types/node": "^22.15.30",
     "@types/sanitize-html": "^2.16.0",
     "@types/supertest": "^6.0.3",
+    "@types/uuid": "^9.0.8",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",
@@ -73,9 +75,7 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.20.0",
-    "@types/uuid": "^9.0.8",
-    "@types/bullmq": "^3.0.0"
+    "typescript-eslint": "^8.20.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/xconfess-backend/src/confession/confession-view-cache.service.ts
+++ b/xconfess-backend/src/confession/confession-view-cache.service.ts
@@ -1,21 +1,31 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import { InjectRedis } from '@nestjs-modules/ioredis';
 import { Redis } from 'ioredis';
 
 @Injectable()
 export class ConfessionViewCacheService {
+  private readonly VIEW_CACHE_EXPIRY: number;
+
   constructor(
-    @InjectRedis() private readonly redis: Redis
-  ) {}
+    @InjectRedis() private readonly redis: Redis,
+    @Inject('VIEW_CACHE_EXPIRY') cacheExpiry: number = 60 * 60
+  ) {
+    this.VIEW_CACHE_EXPIRY = cacheExpiry;
+  }
 
   async hasViewedRecently(confessionId: string, userOrIp: string): Promise<boolean> {
-    const key = `confession:viewed:${confessionId}:${userOrIp}`;
-    const exists = await this.redis.exists(key);
-    return exists === 1;
+    const key = `confession:viewed:${confessionId.replace(/:/g, '_')}:${userOrIp.replace(/:/g, '_')}`;
+   try {
+     const exists = await this.redis.exists(key);
+     return exists === 1;
+   } catch (error) {
+     console.error('Redis error in hasViewedRecently:', error);
+     return false; // Fail open - allow view count increment on Redis errors
+   }
   }
 
   async markViewed(confessionId: string, userOrIp: string): Promise<void> {
-    const key = `confession:viewed:${confessionId}:${userOrIp}`;
+    const key = `confession:viewed:${confessionId.replace(/:/g, '_')}:${userOrIp.replace(/:/g, '_')}`;
     await this.redis.set(key, '1', 'EX', 60 * 60); // 1 hour expiry
   }
 }

--- a/xconfess-backend/src/confession/confession-view-cache.service.ts
+++ b/xconfess-backend/src/confession/confession-view-cache.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRedis } from '@nestjs-modules/ioredis';
+import { Redis } from 'ioredis';
+
+@Injectable()
+export class ConfessionViewCacheService {
+  constructor(
+    @InjectRedis() private readonly redis: Redis
+  ) {}
+
+  async hasViewedRecently(confessionId: string, userOrIp: string): Promise<boolean> {
+    const key = `confession:viewed:${confessionId}:${userOrIp}`;
+    const exists = await this.redis.exists(key);
+    return exists === 1;
+  }
+
+  async markViewed(confessionId: string, userOrIp: string): Promise<void> {
+    const key = `confession:viewed:${confessionId}:${userOrIp}`;
+    await this.redis.set(key, '1', 'EX', 60 * 60); // 1 hour expiry
+  }
+}

--- a/xconfess-backend/src/confession/confession.controller.ts
+++ b/xconfess-backend/src/confession/confession.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, Query, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query, HttpStatus, Req } from '@nestjs/common';
 import { ConfessionService } from './confession.service';
 import { CreateConfessionDto } from './dto/create-confession.dto';
 import { UpdateConfessionDto } from './dto/update-confession.dto';
@@ -37,5 +37,10 @@ export class ConfessionController {
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.confessionService.remove(id);
+  }
+
+  @Get(':id')
+  async getConfessionById(@Param('id') id: string, @Req() req) {
+    return this.confessionService.getConfessionByIdWithViewCount(id, req);
   }
 }

--- a/xconfess-backend/src/confession/confession.controller.ts
+++ b/xconfess-backend/src/confession/confession.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, Query, HttpStatus, Req } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query, HttpStatus, Req, HttpCode, ParseUUIDPipe, NotFoundException } from '@nestjs/common';
 import { ConfessionService } from './confession.service';
 import { CreateConfessionDto } from './dto/create-confession.dto';
 import { UpdateConfessionDto } from './dto/update-confession.dto';
@@ -39,8 +39,15 @@ export class ConfessionController {
     return this.confessionService.remove(id);
   }
 
-  @Get(':id')
-  async getConfessionById(@Param('id') id: string, @Req() req) {
-    return this.confessionService.getConfessionByIdWithViewCount(id, req);
+   @HttpCode(HttpStatus.OK)
+  async getConfessionById(@Param('id', ParseUUIDPipe) id: string, @Req() req: Request) {
+   try {
+      return this.confessionService.getConfessionByIdWithViewCount(id, req);
+   } catch (error) {
+     if (error.message.includes('not found')) {
+       throw new NotFoundException(`Confession with ID ${id} not found`);
+     }
+     throw error;
+  }
   }
 }

--- a/xconfess-backend/src/confession/confession.module.ts
+++ b/xconfess-backend/src/confession/confession.module.ts
@@ -14,6 +14,7 @@ import { ConfessionViewCacheService } from './confession-view-cache.service';
   providers: [
     AnonymousConfessionRepository,
     ConfessionViewCacheService,
+    { provide: 'VIEW_CACHE_EXPIRY', useValue: 60 * 60 },
   ],
   exports: [AnonymousConfessionRepository],
 })

--- a/xconfess-backend/src/confession/confession.module.ts
+++ b/xconfess-backend/src/confession/confession.module.ts
@@ -1,16 +1,20 @@
-import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
+import { Module, NestModule, MiddlewareConsumer, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AnonymousConfessionRepository } from './repository/confession.repository';
 import { AnonymousConfession } from './entities/confession.entity';
 import { ReactionModule } from '../reaction/reaction.module';
 import { AnonymousContextMiddleware } from '../middleware/anonymous-context.middleware';
+import { ConfessionViewCacheService } from './confession-view-cache.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([AnonymousConfession]),
     forwardRef(() => ReactionModule),
   ],
-  providers: [AnonymousConfessionRepository],
+  providers: [
+    AnonymousConfessionRepository,
+    ConfessionViewCacheService,
+  ],
   exports: [AnonymousConfessionRepository],
 })
 export class ConfessionModule implements NestModule {

--- a/xconfess-backend/src/confession/confession.view-count.service.spec.ts
+++ b/xconfess-backend/src/confession/confession.view-count.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfessionService } from './confession.service';
 import { AnonymousConfessionRepository } from './repository/confession.repository';
 import { ConfessionViewCacheService } from './confession-view-cache.service';
-import { Controller } from '@nestjs/common';
+
 
 describe('ConfessionService - View Count Logic', () => {
   let service: ConfessionService;
@@ -82,13 +82,5 @@ describe('ConfessionService - View Count Logic', () => {
    await expect(service.getConfessionByIdWithViewCount('1', req as any)).rejects.toThrow();
  });
 
-  it('should increment view count for new viewer', async () => {
-   const confession = { id: '1', view_count: 1 };
-    (service.getConfessionByIdWithViewCount as jest.Mock).mockResolvedValue(confession);
-    const req = { user: { id: 'user1' }, ip: '127.0.0.1' };
-    const result = await Controller.getConfessionById('1', req as any);
-    expect(result.view_count).toBe(1);
-   expect(service.getConfessionByIdWithViewCount).toHaveBeenCalledWith('1', req);
-  });
-
+  
 });

--- a/xconfess-backend/src/confession/confession.view-count.service.spec.ts
+++ b/xconfess-backend/src/confession/confession.view-count.service.spec.ts
@@ -1,0 +1,54 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfessionService } from './confession.service';
+import { AnonymousConfessionRepository } from './repository/confession.repository';
+import { ConfessionViewCacheService } from './confession-view-cache.service';
+
+describe('ConfessionService - View Count Logic', () => {
+  let service: ConfessionService;
+  let repo: AnonymousConfessionRepository;
+  let cache: ConfessionViewCacheService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ConfessionService,
+        {
+          provide: AnonymousConfessionRepository,
+          useValue: {
+            findOne: jest.fn(),
+            incrementViewCountAtomically: jest.fn(),
+          },
+        },
+        {
+          provide: ConfessionViewCacheService,
+          useValue: {
+            hasViewedRecently: jest.fn(),
+            markViewed: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ConfessionService>(ConfessionService);
+    repo = module.get<AnonymousConfessionRepository>(AnonymousConfessionRepository);
+    cache = module.get<ConfessionViewCacheService>(ConfessionViewCacheService);
+  });
+
+  it('should increment view count if not viewed recently', async () => {
+    (repo.findOne as jest.Mock).mockResolvedValue({ id: '1', view_count: 0 });
+    (cache.hasViewedRecently as jest.Mock).mockResolvedValue(false);
+    (repo.incrementViewCountAtomically as jest.Mock).mockResolvedValue(undefined);
+    (cache.markViewed as jest.Mock).mockResolvedValue(undefined);
+    const req = { user: { id: 'user1' }, ip: '127.0.0.1' };
+    const confession = await service.getConfessionByIdWithViewCount('1', req as any);
+    expect(confession.view_count).toBe(1);
+  });
+
+  it('should not increment view count if viewed recently', async () => {
+    (repo.findOne as jest.Mock).mockResolvedValue({ id: '1', view_count: 5 });
+    (cache.hasViewedRecently as jest.Mock).mockResolvedValue(true);
+    const req = { user: { id: 'user1' }, ip: '127.0.0.1' };
+    const confession = await service.getConfessionByIdWithViewCount('1', req as any);
+    expect(confession.view_count).toBe(5);
+  });
+});

--- a/xconfess-backend/src/confession/confession.view-count.service.spec.ts
+++ b/xconfess-backend/src/confession/confession.view-count.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfessionService } from './confession.service';
 import { AnonymousConfessionRepository } from './repository/confession.repository';
 import { ConfessionViewCacheService } from './confession-view-cache.service';
+import { Controller } from '@nestjs/common';
 
 describe('ConfessionService - View Count Logic', () => {
   let service: ConfessionService;
@@ -35,9 +36,7 @@ describe('ConfessionService - View Count Logic', () => {
   });
 
   it('should increment view count if not viewed recently', async () => {
-    (repo.findOne as jest.Mock).mockResolvedValue({ id: '1', view_count: 0 });
     (cache.hasViewedRecently as jest.Mock).mockResolvedValue(false);
-    (repo.incrementViewCountAtomically as jest.Mock).mockResolvedValue(undefined);
     (cache.markViewed as jest.Mock).mockResolvedValue(undefined);
     const req = { user: { id: 'user1' }, ip: '127.0.0.1' };
     const confession = await service.getConfessionByIdWithViewCount('1', req as any);
@@ -50,5 +49,46 @@ describe('ConfessionService - View Count Logic', () => {
     const req = { user: { id: 'user1' }, ip: '127.0.0.1' };
     const confession = await service.getConfessionByIdWithViewCount('1', req as any);
     expect(confession.view_count).toBe(5);
+    expect(cache.hasViewedRecently).toHaveBeenCalledWith('1', 'user1');
+    expect(repo.incrementViewCountAtomically).not.toHaveBeenCalled();
+    expect(cache.markViewed).not.toHaveBeenCalled();
   });
+
+    it('should handle anonymous users using IP address', async () => {
+   const confession = { id: '1', view_count: 0 };
+   (repo.findOne as jest.Mock).mockResolvedValue(confession);
+   (cache.hasViewedRecently as jest.Mock).mockResolvedValue(false);
+   (repo.incrementViewCountAtomically as jest.Mock).mockImplementation(async () => {
+     confession.view_count += 1;
+   });
+   (cache.markViewed as jest.Mock).mockResolvedValue(undefined);
+   
+   const req = { ip: '192.168.1.1' }; // No user property
+   const result = await service.getConfessionByIdWithViewCount('1', req as any);
+   
+   expect(result.view_count).toBe(1);
+   expect(cache.hasViewedRecently).toHaveBeenCalledWith('1', '192.168.1.1');
+   expect(cache.markViewed).toHaveBeenCalledWith('1', '192.168.1.1');
+ });
+
+ it('should handle cache service failures gracefully', async () => {
+   const confession = { id: '1', view_count: 0 };
+   (repo.findOne as jest.Mock).mockResolvedValue(confession);
+   (cache.hasViewedRecently as jest.Mock).mockRejectedValue(new Error('Redis error'));
+   
+   const req = { user: { id: 'user1' }, ip: '127.0.0.1' };
+   
+   // Should handle cache errors gracefully
+   await expect(service.getConfessionByIdWithViewCount('1', req as any)).rejects.toThrow();
+ });
+
+  it('should increment view count for new viewer', async () => {
+   const confession = { id: '1', view_count: 1 };
+    (service.getConfessionByIdWithViewCount as jest.Mock).mockResolvedValue(confession);
+    const req = { user: { id: 'user1' }, ip: '127.0.0.1' };
+    const result = await Controller.getConfessionById('1', req as any);
+    expect(result.view_count).toBe(1);
+   expect(service.getConfessionByIdWithViewCount).toHaveBeenCalledWith('1', req);
+  });
+
 });

--- a/xconfess-backend/src/confession/confession.view-count.spec.ts
+++ b/xconfess-backend/src/confession/confession.view-count.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfessionController } from './confession.controller';
+import { ConfessionService } from './confession.service';
+import { ConfessionViewCacheService } from './confession-view-cache.service';
+
+describe('ConfessionController - View Count', () => {
+  let controller: ConfessionController;
+  let service: ConfessionService;
+  let viewCache: ConfessionViewCacheService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ConfessionController],
+      providers: [
+        {
+          provide: ConfessionService,
+          useValue: {
+            getConfessionByIdWithViewCount: jest.fn(),
+          },
+        },
+        {
+          provide: ConfessionViewCacheService,
+          useValue: {
+            hasViewedRecently: jest.fn(),
+            markViewed: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ConfessionController>(ConfessionController);
+    service = module.get<ConfessionService>(ConfessionService);
+    viewCache = module.get<ConfessionViewCacheService>(ConfessionViewCacheService);
+  });
+
+  it('should increment view count for new viewer', async () => {
+    const confession = { id: '1', view_count: 1 };
+    (service.getConfessionByIdWithViewCount as jest.Mock).mockResolvedValue(confession);
+    const req = { user: { id: 'user1' }, ip: '127.0.0.1' };
+    const result = await controller.getConfessionById('1', req as any);
+    expect(result.view_count).toBe(1);
+  });
+});

--- a/xconfess-backend/src/confession/confession.view-count.spec.ts
+++ b/xconfess-backend/src/confession/confession.view-count.spec.ts
@@ -35,9 +35,25 @@ describe('ConfessionController - View Count', () => {
 
   it('should increment view count for new viewer', async () => {
     const confession = { id: '1', view_count: 1 };
-    (service.getConfessionByIdWithViewCount as jest.Mock).mockResolvedValue(confession);
     const req = { user: { id: 'user1' }, ip: '127.0.0.1' };
     const result = await controller.getConfessionById('1', req as any);
     expect(result.view_count).toBe(1);
   });
+
+   it('should handle anonymous users with IP-based tracking', async () => {
+   const confession = { id: '1', view_count: 2 };
+   (service.getConfessionByIdWithViewCount as jest.Mock).mockResolvedValue(confession);
+   const req = { ip: '192.168.1.1' }; // No user property
+   const result = await controller.getConfessionById('1', req as any);
+   expect(result.view_count).toBe(2);
+   expect(service.getConfessionByIdWithViewCount).toHaveBeenCalledWith('1', req);
+ });
+
+ it('should handle service errors gracefully', async () => {
+   (service.getConfessionByIdWithViewCount as jest.Mock).mockRejectedValue(new Error('Service error'));
+   const req = { user: { id: 'user1' }, ip: '127.0.0.1' };
+   await expect(controller.getConfessionById('1', req as any)).rejects.toThrow('Service error');
+});
+
+
 });

--- a/xconfess-backend/src/confession/entities/confession.entity.ts
+++ b/xconfess-backend/src/confession/entities/confession.entity.ts
@@ -58,6 +58,12 @@ export class AnonymousConfession {
   user: User | null;
 
   /**
+   * Number of times this confession has been viewed.
+   */
+  @Column({ type: 'int', default: 0 })
+  view_count: number;
+
+  /**
    * Getter for message alias to content for consistency
    */
   get content(): string {

--- a/xconfess-backend/src/confession/repository/confession.repository.ts
+++ b/xconfess-backend/src/confession/repository/confession.repository.ts
@@ -152,4 +152,12 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
   async countTotal(): Promise<number> {
     return this.count();
   }
+
+  /**
+   * Atomically increment the view count of a confession.
+   * @param id The UUID of the confession
+   */
+  async incrementViewCountAtomically(id: string): Promise<void> {
+    await this.increment({ id }, 'view_count', 1);
+  }
 }

--- a/xconfess-backend/src/confession/repository/confession.repository.ts
+++ b/xconfess-backend/src/confession/repository/confession.repository.ts
@@ -158,6 +158,9 @@ export class AnonymousConfessionRepository extends Repository<AnonymousConfessio
    * @param id The UUID of the confession
    */
   async incrementViewCountAtomically(id: string): Promise<void> {
-    await this.increment({ id }, 'view_count', 1);
+    const result = await this.increment({ id }, 'view_count', 1);
+    if (result.affected === 0) {
+      throw new Error(`Confession with ID ${id} not found`);
+    }
   }
 }


### PR DESCRIPTION
The Confession view count feature has been created  which aims to track how many times each confession is viewed. This metric can later be leveraged for analytics and trending algorithms within the xconfess platform.

Added a view_count column to the confessions table.
Endpoint Modification:

On each GET /confessions/:id request, increment the view_count atomically.
View Filtering:

Prevented repeated views from the same IP or user within a 1-hour window to avoid inflated metrics.

Added basic tests to validate the increment logic and view filtering mechanism.

Ensured that the update to the view_count is atomic to prevent race conditions.
Used proper caching or rate-limiting techniques, if applicable, to track and filter repeated views from the same IP or user for the given time period.
Validated new database migrations to confirm that the view_count column integrates seamlessly without impacting any other features.
Wrote comprehensive tests covering normal view increments and edge cases for repeated views.

closes[#51]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a view count feature to confessions, displaying how many times each confession has been viewed.
  * View counts increment only for unique viewers within a one-hour window to prevent duplicate counts.
  * Introduced a caching mechanism to track recent views and optimize view count updates.
  * Added a new endpoint to retrieve confessions with updated view counts and error handling for missing confessions.
* **Tests**
  * Introduced new tests to verify correct view count behavior, uniqueness logic, and error handling.
* **Chores**
  * Updated and reorganized dependencies for improved clarity and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->