### PR TITLE
feat(comments): soft‑delete support (closes #63)

### DIFF
--- a/xconfess-backend/src/comment/comment.controller.ts
+++ b/xconfess-backend/src/comment/comment.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Post,
+  Body,
+  Param,
+  Delete,
+  Get,
+  UseGuards,
+  Req,
+} from '@nestjs/common';
+import { CommentService } from './comment.service';
+import { AuthGuard } from '../auth/auth.guard';
+import { Request } from 'express';
+
+@Controller('comments')
+export class CommentController {
+  constructor(private readonly service: CommentService) {}
+
+  @UseGuards(AuthGuard)
+  @Post(':confessionId')
+  create(
+    @Param('confessionId') confessionId: string,
+    @Body('content') content: string,
+    @Req() req: Request,
+    @Body('anonymousContextId') anonymousContextId: string,
+  ) {
+    const user = req.user as any; 
+    return this.service.create(content, user, confessionId, anonymousContextId);
+  }
+
+  @Get('by-confession/:confessionId')
+  findByConfession(@Param('confessionId') confessionId: string) {
+    return this.service.findByConfessionId(confessionId);
+  }
+
+  @UseGuards(AuthGuard)
+  @Delete(':id')
+  remove(@Param('id') id: string, @Req() req: Request) {
+    const user = req.user as any;
+    return this.service.delete(+id, user);
+  }
+}

--- a/xconfess-backend/src/comment/comment.module.ts
+++ b/xconfess-backend/src/comment/comment.module.ts
@@ -3,13 +3,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommentController } from './comment.controller';
 import { CommentService } from './comment.service';
 import { Comment } from './entities/comment.entity';
-import { AnonymousContextMiddleware } from '../middleware/anonymous-context.middleware';
 import { AnonymousConfession } from '../confession/entities/confession.entity';
+import { AnonymousContextMiddleware } from '../middleware/anonymous-context.middleware';
+import { NotificationQueue } from '../notification/notification.queue';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Comment, AnonymousConfession])],
+  imports: [
+    TypeOrmModule.forFeature([Comment, AnonymousConfession]),
+  ],
   controllers: [CommentController],
-  providers: [CommentService],
+  providers: [CommentService, NotificationQueue],
   exports: [CommentService],
 })
 export class CommentModule implements NestModule {
@@ -18,4 +21,4 @@ export class CommentModule implements NestModule {
       .apply(AnonymousContextMiddleware)
       .forRoutes('comments');
   }
-} 
+}

--- a/xconfess-backend/src/comment/comment.service.spec.ts
+++ b/xconfess-backend/src/comment/comment.service.spec.ts
@@ -1,0 +1,125 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository, UpdateResult } from 'typeorm';
+import { CommentService } from './comment.service';
+import { Comment } from './entities/comment.entity';
+import { AnonymousConfession } from '../confession/entities/confession.entity';
+import { NotificationQueue } from '../notification/notification.queue';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+
+describe('CommentService (soft‑delete)', () => {
+  let service: CommentService;
+  let commentRepo: jest.Mocked<Repository<Comment>>;
+  let confessionRepo: jest.Mocked<Repository<AnonymousConfession>>;
+  let queue: jest.Mocked<NotificationQueue>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommentService,
+        {
+          provide: getRepositoryToken(Comment),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+            update: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(AnonymousConfession),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: NotificationQueue,
+          useValue: { enqueueCommentNotification: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(CommentService);
+    commentRepo = module.get(getRepositoryToken(Comment));
+    confessionRepo = module.get(getRepositoryToken(AnonymousConfession));
+    queue = module.get(NotificationQueue);
+  });
+
+  describe(`findByConfessionId()`, () => {
+    it(`calls find() with isDeleted: false`, async () => {
+      commentRepo.find.mockResolvedValue([]);
+      await service.findByConfessionId('conf1');
+      expect(commentRepo.find).toHaveBeenCalledWith({
+        where: { confession: { id: 'conf1' }, isDeleted: false },
+        order: { createdAt: 'DESC' },
+      });
+    });
+  });
+
+  describe(`delete()`, () => {
+    const fakeUser = { id: 11 } as any;
+    const goodComment = {
+      id: 42,
+      user: { id: 11 },
+      isDeleted: false,
+    } as any;
+
+    it(`sets isDeleted to true when user owns it`, async () => {
+      commentRepo.findOne.mockResolvedValue(goodComment);
+      (commentRepo.update as jest.Mock).mockResolvedValue({ affected: 1 } as UpdateResult);
+
+      await expect(service.delete(42, fakeUser)).resolves.toBeUndefined();
+      expect(commentRepo.update).toHaveBeenCalledWith(42, { isDeleted: true });
+    });
+
+    it(`throws NotFoundException if comment not found`, async () => {
+      commentRepo.findOne.mockResolvedValue(null);
+      await expect(service.delete(99, fakeUser)).rejects.toThrow(NotFoundException);
+    });
+
+    it(`throws BadRequestException if user doesn’t own comment`, async () => {
+      commentRepo.findOne.mockResolvedValue({ id: 42, user: { id: 77 }, isDeleted: false } as any);
+      await expect(service.delete(42, fakeUser)).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe(`create()`, () => {
+    const fakeUser = { id: 5 } as any;
+    const fakeConf = { id: 'c1', user: { email: 'a@b.com' }, isDeleted: false } as any;
+    const fakeComment = { id: 101, content: 'hey', user: fakeUser, confession: fakeConf } as any;
+
+    it(`throws if confession not found or deleted`, async () => {
+      confessionRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.create('hey', fakeUser, 'c1', 'anonCtx'),
+      ).rejects.toThrow(NotFoundException);
+
+      confessionRepo.findOne.mockResolvedValue({ ...fakeConf, isDeleted: true });
+      await expect(
+        service.create('hey', fakeUser, 'c1', 'anonCtx'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it(`creates, saves, and enqueues notification`, async () => {
+      confessionRepo.findOne.mockResolvedValue(fakeConf);
+      commentRepo.create.mockReturnValue(fakeComment);
+      commentRepo.save.mockResolvedValue(fakeComment);
+
+      const result = await service.create('hey', fakeUser, 'c1', 'anonCtx');
+      expect(commentRepo.create).toHaveBeenCalledWith({
+        content: 'hey',
+        user: fakeUser,
+        confession: fakeConf,
+        anonymousContextId: 'anonCtx',
+      });
+      expect(commentRepo.save).toHaveBeenCalledWith(fakeComment);
+      expect(queue.enqueueCommentNotification).toHaveBeenCalledWith({
+        confession: fakeConf,
+        comment: fakeComment,
+        recipientEmail: 'a@b.com',
+      });
+      expect(result).toBe(fakeComment);
+    });
+  });
+});

--- a/xconfess-backend/src/comment/entities/comment.entity.ts
+++ b/xconfess-backend/src/comment/entities/comment.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity, Column, PrimaryGeneratedColumn,
+  CreateDateColumn, ManyToOne, JoinColumn
+} from '@nestjs/typeorm';
+import { User } from '../../user/entities/user.entity';
+import { AnonymousConfession } from '../../confession/entities/confession.entity';
+
+@Entity('comments')
+export class Comment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  content: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne(() => User, user => user.comments)
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @ManyToOne(() => AnonymousConfession, c => c.comments)
+  @JoinColumn({ name: 'confessionId' })
+  confession: AnonymousConfession;
+
+  @Column({ nullable: true })
+  anonymousContextId?: string;
+
+  @Column({ default: false })
+  isDeleted: boolean;
+}


### PR DESCRIPTION
closes #63
What’s Changed

Introduces isDeleted flag on Comment entity

Updates findByConfessionId() to filter out soft‑deleted comments

Replaces hard delete in CommentService.delete() with a “soft” update of isDeleted = true

Adjusts repository queries to respect isDeleted on lookup

Adds unit tests covering:

Soft‑delete behavior (authorized vs. unauthorized)

Read filtering of deleted comments

Creation flow with notification enqueue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for commenting on confessions, including creating, viewing, and deleting comments.
  * Introduced soft-delete functionality for comments, allowing deleted comments to be hidden rather than removed.
  * Added anonymous commenting options.

* **Bug Fixes**
  * Ensured deleted confessions and comments are excluded from queries.

* **Tests**
  * Added comprehensive tests for comment creation, retrieval, and soft-deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->